### PR TITLE
Rollback a head finder😥

### DIFF
--- a/extension/userscript.user.js
+++ b/extension/userscript.user.js
@@ -747,8 +747,12 @@ function main() {
     if (head !== null && head !== undefined) {
       headFound(head);
     } else {
-      headFinder((head) => {
-        headFound(head);
+      const i = setInterval(() => {
+        const head = document.head;
+        if (head !== undefined && head !== null) {
+          clearInterval(i);
+          headFound(head);
+        }
       });
     }
   } else {


### PR DESCRIPTION
https://greasyfork.org/ja/scripts/471572-x-to-twitter/discussions/270551

Maybe maybe, Some environments do not support the feature that MutationObserver is runned before page loaded.
So now, It's feature used in chrome ext env only cuz replacing manifest must be runned as soon as possible.